### PR TITLE
Improve whitespace consistency and add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,8 @@ async function printContactenation(files, log) {
     return "// File: " + file + "\n\n" + await fileContentWithoutImports(file);
   }));
 
-  log(parts.join());
+  // add a single empty line between parts
+  log(parts.join("\n"));
 }
 
 async function getTruffleRoot() {

--- a/tests/contracts/whitespace/missing-trailing-newline.sol
+++ b/tests/contracts/whitespace/missing-trailing-newline.sol
@@ -1,0 +1,1 @@
+// This file misses a trailing newline. But flattener is nice and adds it.

--- a/tests/contracts/whitespace/simple.sol
+++ b/tests/contracts/whitespace/simple.sol
@@ -1,0 +1,1 @@
+// A simple contract

--- a/tests/contracts/whitespace/with-imports.sol
+++ b/tests/contracts/whitespace/with-imports.sol
@@ -1,0 +1,4 @@
+import "./simple.sol";
+import "./missing-trailing-newline.sol";
+
+// including others

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -92,4 +92,22 @@ describe("flattening", function() {
 
     assert.equal(content, expected);
   });
+
+  it("Should add empty line between imported files", async function() {
+    const content = await flatten(["./contracts/whitespace/with-imports.sol"]);
+    const expected =
+      "// File: contracts/whitespace/simple.sol\n" +
+      "\n" +
+      "// A simple contract\n" +
+      "\n" +
+      "// File: contracts/whitespace/missing-trailing-newline.sol\n" +
+      "\n" +
+      "// This file misses a trailing newline. But flattener is nice and adds it.\n" +
+      "\n" +
+      "// File: contracts/whitespace/with-imports.sol\n" +
+      "\n" +
+      "// including others\n";
+
+    assert.equal(content, expected);
+  });
 });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -74,4 +74,22 @@ describe("flattening", function() {
     assert.include(flattened, "pragma solidity >=0.4.24 <0.6.0;");
     assert.include(flattened, "pragma solidity ^0.5.2;");
   });
+
+  it("Should have proper whitespacing for the simple case", async function() {
+    const content = await flatten(["./contracts/whitespace/simple.sol"]);
+    const expected = "// File: contracts/whitespace/simple.sol\n"
+      + "\n"
+      + "// A simple contract\n";
+
+    assert.equal(content, expected);
+  });
+
+  it("Should add missing trailing newlines", async function() {
+    const content = await flatten(["./contracts/whitespace/missing-trailing-newline.sol"]);
+    const expected = "// File: contracts/whitespace/missing-trailing-newline.sol\n"
+      + "\n"
+      + "// This file misses a trailing newline. But flattener is nice and adds it.\n";
+
+    assert.equal(content, expected);
+  });
 });


### PR DESCRIPTION
- The `flatten` function is now responsible for adding the trailing newline instead of the callers. (because [every POSIX line should end with a newline character](https://stackoverflow.com/a/729795/2013738))
- Removes empty lines at the top of the output document
- Tests 🎉 