### PR TITLE
Add root argument to `flatten` function

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,8 +148,14 @@ function getFilePathsFromTruffleRoot(filePaths, truffleRoot) {
   return filePaths.map(f => path.relative(truffleRoot, path.resolve(f)));
 }
 
-async function flatten(filePaths, log) {
-  const truffleRoot = await getTruffleRoot();
+async function flatten(filePaths, log, root) {
+  if (root && !fs.existsSync(root)) {
+    throw new Error(
+      "The specified root directory does not exist"
+    );
+  }
+
+  const truffleRoot = root || await getTruffleRoot();
   const filePathsFromTruffleRoot = getFilePathsFromTruffleRoot(
     filePaths,
     truffleRoot
@@ -231,8 +237,8 @@ if (require.main === module) {
   main(process.argv.slice(2)).catch(console.error);
 }
 
-module.exports = async function(filePaths) {
+module.exports = async function(filePaths, root) {
   let res = "";
-  await flatten(filePaths, str => (res += str + "\n"));
+  await flatten(filePaths, str => (res += str + "\n"), root);
   return res;
 };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -74,4 +74,13 @@ describe("flattening", function() {
     assert.include(flattened, "pragma solidity >=0.4.24 <0.6.0;");
     assert.include(flattened, "pragma solidity ^0.5.2;");
   });
+
+  it("Should fail if the provided root directory does not exist", async function() {
+    try {
+      await flatten(["./contracts/child.sol"], "no valid directory");
+      assert.fail("This should have failed");
+    } catch (error) {
+      assert.strictEqual(error.message, "The specified root directory does not exist");
+    }
+  });
 });


### PR DESCRIPTION
This PR adds a `root` argument to the `flatten` function, so that the root directory can be specified without having to depend on whether a `truffle.js` or `truffle-config.js` file exists or not.