### PR TITLE
switch to solidity-parser-diligence to support Solidity 0.6

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const fs = require("fs");
 const path = require("path");
 const findUp = require("find-up");
 const tsort = require("tsort");
-const parser = require("solidity-parser-antlr");
+const parser = require("solidity-parser-diligence");
 const mkdirp = require("mkdirp");
 const Resolver = require("@resolver-engine/imports-fs").ImportsFsEngine;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -605,10 +605,10 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "solidity-parser-antlr": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.0.tgz",
-      "integrity": "sha512-RrIsh5VoHmrMQia6yLY8u8rx3JPREhSiCFz4Xb0h1Oh0prUYU2ukyWO8gG892V0UMHIXCWqvdZ3wSctNwdWThg=="
+    "solidity-parser-diligence": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/solidity-parser-diligence/-/solidity-parser-diligence-0.4.18.tgz",
+      "integrity": "sha512-mauO/qG2v59W9sOn5TYV2dS7+fvFKqIHwiku+TH82e1Yca4H8s6EDG12ZpXO2cmgLlCKX3FOqqC73aYLB8WwNg=="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@resolver-engine/imports-fs": "^0.2.2",
     "find-up": "^2.1.0",
     "mkdirp": "^0.5.1",
-    "solidity-parser-antlr": "^0.4.0",
+    "solidity-parser-diligence": "^0.4.18",
     "tsort": "0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Switching to solidity-parser-diligence adds support for Solidity 0.6, see #47 - there are some newer pieces of Solidity syntax we will be able to cover when the parser is updated further.