### PR TITLE
Update solidity parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-flattener",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.5.2.tgz",
-      "integrity": "sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.0.tgz",
+      "integrity": "sha512-RiJXfS22frulogcfQCFhbKrd5ATu6P4tYUv/daChiIh6VHyKQ1kkVZVfX6aP7c2YGU/Bf9RwGNKdwLjfpaoqYQ=="
     },
     "ajv": {
       "version": "6.9.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@resolver-engine/imports-fs": "^0.2.2",
-    "@solidity-parser/parser": "^0.5.2",
+    "@solidity-parser/parser": "^0.6.0",
     "find-up": "^2.1.0",
     "mkdirp": "^1.0.4",
     "tsort": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-flattener",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Truffle Flattener concats solidity files developed under Truffle with all of their dependencies",
   "bin": {
     "truffle-flattener": "index.js"


### PR DESCRIPTION
@alcuadrado I have Updated `@solidity-parser/parser` package  version to support solidity `0.6.x`. Also bumped package version so this can be released on npm.
