### PR TITLE
Add fix for cyclic dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,9 +67,8 @@ async function dependenciesDfs(graph, visitedFiles, filePath) {
   );
 
   for (let dependency of dependencies) {
-    graph.add(dependency, filePath);
-
     if (!visitedFiles.includes(dependency)) {
+      graph.add(dependency, filePath);
       await dependenciesDfs(graph, visitedFiles, dependency);
     }
   }


### PR DESCRIPTION
There is an open issue (#14) regarding cyclic dependencies. It seems to me that there might be a really simple fix for this if we don't add the dependencies to the graph if those were already visited. You can see the implementation below.

I've successfully verified a contract with 20+ dependencies which was failing before, however, given the fact that the fix is so simple I'm questioning myself whether I missed something. I'll open this PR as a draft in order to discuss the proposed fix and see if there's anything that it breaks.