### PR TITLE
Update solidity-parser version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.0.tgz",
-      "integrity": "sha512-RiJXfS22frulogcfQCFhbKrd5ATu6P4tYUv/daChiIh6VHyKQ1kkVZVfX6aP7c2YGU/Bf9RwGNKdwLjfpaoqYQ=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.7.1.tgz",
+      "integrity": "sha512-5ma2uuwPAEX1TPl2rAPAAuGlBkKnn2oUKQvnhTFlDIB8U/KDWX77FpHtL6Rcz+OwqSCWx9IClxACgyIEJ/GhIw=="
     },
     "ajv": {
       "version": "6.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.7.1.tgz",
-      "integrity": "sha512-5ma2uuwPAEX1TPl2rAPAAuGlBkKnn2oUKQvnhTFlDIB8U/KDWX77FpHtL6Rcz+OwqSCWx9IClxACgyIEJ/GhIw=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.0.tgz",
+      "integrity": "sha512-4Eg1iWe6ZuJC9Ynfd8D2cnu06So0QL6V3i+fgQRqT8twPMr+N+kUvS5K7ILgWpuoAag/jb3r0wBDfmpib+yvaw=="
     },
     "ajv": {
       "version": "6.9.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Nomic Labs SRL",
   "license": "MIT",
   "dependencies": {
-    "@resolver-engine/imports-fs": "0.2.2",
+    "@resolver-engine/imports-fs": "^0.2.2",
     "@solidity-parser/parser": "^0.7.0",
     "find-up": "^2.1.0",
     "mkdirp": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@resolver-engine/imports-fs": "^0.2.2",
-    "@solidity-parser/parser": "^0.7.0",
+    "@solidity-parser/parser": "^0.8.0",
     "find-up": "^2.1.0",
     "mkdirp": "^1.0.4",
     "tsort": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "author": "Nomic Labs SRL",
   "license": "MIT",
   "dependencies": {
-    "@resolver-engine/imports-fs": "^0.2.2",
-    "@solidity-parser/parser": "^0.6.0",
+    "@resolver-engine/imports-fs": "0.2.2",
+    "@solidity-parser/parser": "^0.7.0",
     "find-up": "^2.1.0",
     "mkdirp": "^1.0.4",
     "tsort": "0.0.1"

--- a/tests/contracts/child.sol
+++ b/tests/contracts/child.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.24 <0.7.0;
+pragma solidity >=0.4.24 <0.8.0;
 
 import "./parent.sol";
 import "openzeppelin-solidity/contracts/access/roles/PauserRole.sol";

--- a/tests/contracts/child.sol
+++ b/tests/contracts/child.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.24 <0.6.0;
+pragma solidity >=0.4.24 <0.7.0;
 
 import "./parent.sol";
 import "openzeppelin-solidity/contracts/access/roles/PauserRole.sol";

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -71,7 +71,7 @@ describe("flattening", function() {
     ]);
 
     assert.include(flattened, "pragma solidity ^0.5.0;");
-    assert.include(flattened, "pragma solidity >=0.4.24 <0.6.0;");
+    assert.include(flattened, "pragma solidity >=0.4.24 <0.7.0;");
     assert.include(flattened, "pragma solidity ^0.5.2;");
   });
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -71,7 +71,7 @@ describe("flattening", function() {
     ]);
 
     assert.include(flattened, "pragma solidity ^0.5.0;");
-    assert.include(flattened, "pragma solidity >=0.4.24 <0.7.0;");
+    assert.include(flattened, "pragma solidity >=0.4.24 <0.8.0;");
     assert.include(flattened, "pragma solidity ^0.5.2;");
   });
 


### PR DESCRIPTION
Update solidity-parser version to `^0.8.0` to avoid `Error: Constructors have to be declared either "public" or "internal"` using Solidity 0.7.x.

Closes #58 