### PR TITLE
Fix duplicate SPDX and ABIEncoderV2 lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,29 +234,29 @@ async function main(args) {
     return;
   }
 
-  let outputFileContent = '';
+  let outputFileContent = "";
 
   await flatten(filePaths, (outputChunk) => {
     outputFileContent += outputChunk;
   });
 
   // fix duplicate SPDX license identifiers and abiv2 pragmas
-  const outputLinesArray = outputFileContent.split('\n');
+  const outputLinesArray = outputFileContent.split("\n");
   const licenses = []; // string[]
   const spdxRegex = /SPDX-License-Identifier/;
   const abiv2Regex = /pragma experimental ABIEncoderV2;/;
   let abiV2Exists = false;
   for (const [index, line] of outputLinesArray.entries()) {
     if (spdxRegex.test(line)) {
-      const words = line.split(':');
+      const words = line.split(":");
       const wordIndex = words.findIndex((word) => spdxRegex.test(word)); // Actual license idenfifier after this
 
-      const licenseIdentifier = words[wordIndex + 1].replace(/ /g, '');
+      const licenseIdentifier = words[wordIndex + 1].replace(/ /g, "");
       licenses.push(licenseIdentifier);
       outputLinesArray.splice(index, 1);
     }
     if (abiv2Regex.test(line)) {
-      if(abiV2Exists) {
+      if (abiV2Exists) {
         outputLinesArray.splice(index, 1);
       } else {
         abiV2Exists = true;
@@ -264,17 +264,16 @@ async function main(args) {
     }
   }
   outputLinesArray.unshift(
-    '// SPDX-License-Identifier: ' + [...new Set(licenses)].join(' AND ')
+    "// SPDX-License-Identifier: " + [...new Set(licenses)].join(" AND ")
   );
 
-  outputFileContent = outputLinesArray.join('\n');
+  outputFileContent = outputLinesArray.join("\n");
 
   if (outputFilePath) {
     fs.writeFileSync(outputFilePath, outputFileContent);
   } else {
     process.stdout.write(outputChunk);
   }
-  
 }
 
 if (require.main === module) {

--- a/index.js
+++ b/index.js
@@ -240,18 +240,27 @@ async function main(args) {
     outputFileContent += outputChunk;
   });
 
-  // fix duplicate SPDX license identifiers
+  // fix duplicate SPDX license identifiers and abiv2 pragmas
   const outputLinesArray = outputFileContent.split('\n');
   const licenses = []; // string[]
-  const regex = /SPDX-License-Identifier/;
+  const spdxRegex = /SPDX-License-Identifier/;
+  const abiv2Regex = /pragma experimental ABIEncoderV2;/;
+  let abiV2Exists = false;
   for (const [index, line] of outputLinesArray.entries()) {
-    if (regex.test(line)) {
+    if (spdxRegex.test(line)) {
       const words = line.split(':');
-      const wordIndex = words.findIndex((word) => regex.test(word)); // Actual license idenfifier after this
+      const wordIndex = words.findIndex((word) => spdxRegex.test(word)); // Actual license idenfifier after this
 
       const licenseIdentifier = words[wordIndex + 1].replace(/ /g, '');
       licenses.push(licenseIdentifier);
       outputLinesArray.splice(index, 1);
+    }
+    if (abiv2Regex.test(line)) {
+      if(abiV2Exists) {
+        outputLinesArray.splice(index, 1);
+      } else {
+        abiV2Exists = true;
+      }
     }
   }
   outputLinesArray.unshift(


### PR DESCRIPTION
A quick fix for #48 and #55. This fixed errors on my flattened contract that had a lot of SPDX's and a couple of ABIEncoderV2's.

Before:

```solidity
// SPDX-License-Identifier: MIT
// SPDX-License-Identifier: MIT
// SPDX-License-Identifier: GNU

pragma experimental ABIEncoderV2;
pragma experimental ABIEncoderV2;
```

After:

```solidity
// SPDX-License-Identifier: MIT AND GNU

pragma experimental ABIEncoderV2;
```

Please let me know if any changes are required!

Edit: If anyone wants to try if this PR fixes errors in your flattened contract, you can do so with the temporary package `npm install @zemse/solidity-flattener -g`.